### PR TITLE
SVCPLAN-2680: fix dependencies between yumrepo(s) and installation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -127,5 +127,6 @@ Other depencies to handle prior to other MySQL setup, specified as resources, e.
 
 Data type: `Hash`
 
-Raw params for a yumrepo resource from which to install MySQL/MariaDB.
+Raw params containing a yumrepo resource (or multiple yumrepo resources) from which
+to install MySQL/MariaDB.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,8 @@
 #     - "Mount['/var/lib/mysql']"
 #
 # @param yumrepo
-#   Raw params for a yumrepo resource from which to install MySQL/MariaDB.
+#   Raw params containing a yumrepo resource (or multiple yumrepo resources) from which
+#   to install MySQL/MariaDB.
 #
 # @example
 #   include profile_mysql_server
@@ -161,7 +162,9 @@ class profile_mysql_server (
       }
       ensure_resources( 'yumrepo', $yumrepo, $yumrepo_defaults )
     }
-    Yumrepo[$yumrepo] -> Class['::mysql::server::install']
+    keys($yumrepo).each | $repo | {
+      Yumrepo[$repo] -> Class['::mysql::server::install']
+    }
   }
 
   each($dbs) | $db_name, $db_data | {


### PR DESCRIPTION
The yumrepo param is a hash containing a hash of yumrepo name and yumrepo data (and actually, that could be multiple yumrepos): 
```
profile_mysql_server::yumrepo:
  yumrepo1:
    ensure: present
    baseurl: ...
  yumrepo2:
    ensure: present
    baseurl: ...
```

We need to iterate over the key(s) in the param, i.e., iterate over the yumrepo resource names, when we place dependency/dependencies between the yumrepo(s) and the installation.